### PR TITLE
Remove fs.existsSync()

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,9 @@ module.exports = function isFile(path, cb){
 module.exports.sync = isFileSync;
 
 function isFileSync(path){
-  return fs.existsSync(path) && fs.statSync(path).isFile();
+  try {
+    return fs.statSync(path).isFile();
+  } catch (e) {
+    return false;
+  }
 }

--- a/test/is-file.js
+++ b/test/is-file.js
@@ -38,5 +38,9 @@ describe('is-file', function(){
     it('should return true for files', function(){
       sut(__filename).should.be.true;
     });
+
+    it('should send back false when the path does not exist', function(){
+      sut('asdasdf').should.be.false;
+    });
   });
 });


### PR DESCRIPTION
fs.existsSync() will be deprecated.
https://nodejs.org/api/fs.html#fs_fs_existssync_path

And io.js already deprecated fs.existsSync().
github.com/nodejs/io.js/issues/257
